### PR TITLE
Add a Dragging Mode

### DIFF
--- a/src/widget/droppable.rs
+++ b/src/widget/droppable.rs
@@ -40,7 +40,7 @@ where
             on_drop: None,
             on_drag: None,
             on_cancel: None,
-            drag_mode: None,
+            drag_mode: Some((true, true)),
             drag_overlay: true,
             drag_hide: false,
             drag_size: None,
@@ -100,10 +100,6 @@ where
 
     // Sets whether the [`Droppable`] can be dragged along individual axes.
     pub fn drag_mode(mut self, drag_x: bool, drag_y: bool) -> Self {
-        debug_assert!(
-            drag_x | drag_y,
-            "A Droppable must be draggable on at least one axis"
-        );
         self.drag_mode = Some((drag_x, drag_y));
         self
     }

--- a/src/widget/droppable.rs
+++ b/src/widget/droppable.rs
@@ -99,12 +99,12 @@ where
     }
 
     // Sets whether the [`Droppable`] can be dragged along individual axes.
-    pub fn drag_mode(mut self, drag_mode_x: bool, drag_mode_y: bool) -> Self {
+    pub fn drag_mode(mut self, drag_x: bool, drag_y: bool) -> Self {
         debug_assert!(
-            drag_mode_x | drag_mode_y,
-            "Drag mode must drag on at least x or y axes"
+            drag_x | drag_y,
+            "A Droppable must be draggable on at least one axis"
         );
-        self.drag_mode = (drag_mode_x, drag_mode_y);
+        self.drag_mode = (drag_x, drag_y);
         self
     }
 


### PR DESCRIPTION
This adds a value to the `Droppable` struct that restricts which axes a `Droppable` can be dragged. This is useful for reorderable tabs and lists and the like.

Lmk if anything can be improved!