### PR TITLE
Compile examples with rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --all
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --all


### PR DESCRIPTION
Right now the examples are not compiled on CI, and so their compilation is broken.

This changes makes it that rust.yml will also compile examples and run any tests if for some reason examples would have those.