### PR TITLE
feat: ✨ Add release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,27 @@
+name: release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Automatic release/publish pipeline.

You'll need to do two things to set it up: one mandatory and one optional.

Mandatory step:

1. generate a publish token on crates.io (preferably scoped to iced_drop, needs only "publish new packages" permission)
<img width="971" alt="image" src="https://github.com/user-attachments/assets/11cd6cd4-e245-4be8-87c1-5afdc8d8d3b5">
<img width="950" alt="image" src="https://github.com/user-attachments/assets/b6ca56ac-549e-4384-b609-7fe10a5f4a22">

3. Paste it into an env var called CARGO_REGISTRY_TOKEN in github:

![image](https://github.com/user-attachments/assets/81d42405-d894-487a-b530-8f4a04177635)

Optional step:

1. Add branch protection on the master branch, forbid direct commits (allow only merge commits).

<img width="1124" alt="image" src="https://github.com/user-attachments/assets/b2ad4428-f399-48b9-8e15-ab5d52d33530">
<img width="788" alt="image" src="https://github.com/user-attachments/assets/23851c57-7f3d-4d2a-85fc-40436641f184">
<img width="1143" alt="image" src="https://github.com/user-attachments/assets/8eead6e4-11ad-48c5-b1a4-e05be5a01719">


If you don't - release-plz will trigger a release immediately after a merge to master and will commit a new release into master directly.

With protection, release-plz will create a PR with all the changes it wants to do and only after this PR is merged it will make a tag and a release, so this lets review changes before releasing.
I recommend using branch protection - this will give you a chance to review and update release notes directly in the PR prior to merging it.

NB: Set branch protection prior to merging this PR, otherwise release-plz will publish immediately.