### PR TITLE
fix: on_press regression

### DIFF
--- a/examples/todo/src/tree.rs
+++ b/examples/todo/src/tree.rs
@@ -296,7 +296,7 @@ impl List {
             });
         droppable(content)
             .id(self.id.clone())
-            .on_press(Message::StopEditingTodo)
+            .on_click(Message::StopEditingTodo)
             .on_drop(move |p, r| Message::DropList(location, p, r))
             .on_drag(move |p, r| Message::DragList(location, p, r))
             .on_cancel(Message::ListDropCanceled)

--- a/examples/todo/src/tree.rs
+++ b/examples/todo/src/tree.rs
@@ -296,7 +296,7 @@ impl List {
             });
         droppable(content)
             .id(self.id.clone())
-            .on_click(Message::StopEditingTodo)
+            .on_press(Message::StopEditingTodo)
             .on_drop(move |p, r| Message::DropList(location, p, r))
             .on_drag(move |p, r| Message::DragList(location, p, r))
             .on_cancel(Message::ListDropCanceled)
@@ -379,7 +379,7 @@ impl Todo {
         if !self.editing {
             droppable(content)
                 .id(self.id.clone())
-                .on_click(Message::EditTodo(location, self.t_id.clone()))
+                .on_press(Message::EditTodo(location, self.t_id.clone()))
                 .on_drop(move |p, r| Message::DropTodo(location, p, r))
                 .on_drag(move |_p, r| Message::DragTodo(location, r))
                 .on_cancel(Message::TodoDropCanceled)

--- a/src/widget/droppable.rs
+++ b/src/widget/droppable.rs
@@ -25,6 +25,7 @@ pub struct Droppable<
     id: Option<Id>,
     drag_threshold: f32,
     on_press: Option<Message>,
+    on_click: Option<Message>,
     on_drop: Option<Box<dyn Fn(Point, Rectangle) -> Message + 'a>>,
     on_drag: Option<Box<dyn Fn(Point, Rectangle) -> Message + 'a>>,
     on_cancel: Option<Message>,
@@ -51,6 +52,7 @@ where
             id: None,
             drag_threshold: 5.0,
             on_press: None,
+            on_click: None,
             on_drop: None,
             on_drag: None,
             on_cancel: None,
@@ -81,7 +83,17 @@ where
         self
     }
 
-    /// Sets the message that will be produced when the [`Droppable`] is pressed, but not dragged.
+    /// Sets the message that will be produced when the [`Droppable`] is clicked.
+    ///
+    /// This will get triggered even if drag occurs.
+    pub fn on_click(mut self, message: Message) -> Self {
+        self.on_click = Some(message);
+        self
+    }
+
+    /// Sets the message that will be produced when the [`Droppable`] is pressed.
+    ///
+    /// This will get triggered only when not dragging.
     pub fn on_press(mut self, message: Message) -> Self {
         self.on_press = Some(message);
         self
@@ -320,6 +332,10 @@ where
                         state.widget_pos = bounds.position();
                         state.overlay_bounds.width = bounds.width;
                         state.overlay_bounds.height = bounds.height;
+
+                        if let Some(on_click) = self.on_click.clone() {
+                            shell.publish(on_click);
+                        }
 
                         shell.capture_event();
                     } else if *btn == mouse::Button::Right


### PR DESCRIPTION
We had 3 events for when we click with mouse left button, so I kept one "on_press", chose this one since iced use that name for mouse_area and button widgets, to stay consistent with main widgets.

Those using the on_press on pml68's fork had `on_press` not working and while fixing it, I realised we had 3 events for that click.